### PR TITLE
Upgrade terraform and azurerm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-
 The Application Gateway Ingress Controller allows the [Azure Application Gateway](https://azure.microsoft.com/en-us/services/application-gateway/) to be used as the ingress for an [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/) aka AKS cluster. As shown in the figure below, the ingress controller runs as a pod within the AKS cluster. It consumes [Kubernetes Ingress Resources](https://kubernetes.io/docs/concepts/services-networking/ingress/) and converts them to an Azure Application Gateway configuration which allows the gateway to load-balance traffic to Kubernetes pods.
 
-This module helps in deploying the necessary resources for the greenfield deployment of necessary resources for AKS cluster with Application Gateway as ingress controller. 
+This module helps in deploying the necessary resources for the greenfield deployment of necessary resources for AKS cluster with Application Gateway as ingress controller.
 
 ![Azure Application Gateway + AKS](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/images/architecture.png)
 
@@ -11,7 +10,7 @@ This module helps in deploying the necessary resources for the greenfield deploy
 ## Usage
 Refer to the [tutorials](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/tutorial.md) to understand how you can expose an AKS service over HTTP or HTTPS, to the internet, using an Azure Application Gateway.
 
-## Usage of the module 
+## Usage of the module
 ```hcl
 
 
@@ -27,14 +26,14 @@ resource "azurerm_resource_group" "test" {
 
 
 module "appgw-ingress-k8s-cluster" {
-  source                              = "Azure/appgw-ingress-k8s-cluster/azurerm" 
+  source                              = "Azure/appgw-ingress-k8s-cluster/azurerm"
   version                             = "0.1.0"
-  resource_group_name                 = "${azurerm_resource_group.test.name}"
+  resource_group_name                 = azurerm_resource_group.test.name
   location                            = "westus"
   aks_service_principal_app_id        = "<App ID of the service principal>"
   aks_service_principal_client_secret = "<Client secret of the service principal>"
   aks_service_principal_object_id     = "<Object ID of the service principal>"
-  
+
   tags = {
     environment = "dev"
     costcenter  = "it"

--- a/main.tf
+++ b/main.tf
@@ -192,11 +192,10 @@ resource "azurerm_kubernetes_cluster" "test" {
     }
   }
 
-  agent_pool_profile {
+  default_node_pool {
     name            = "agentpool"
-    count           = var.aks_agent_count
+    node_count      = var.aks_agent_count
     vm_size         = var.aks_agent_vm_size
-    os_type         = "Linux"
     os_disk_size_gb = var.aks_agent_os_disk_size
     vnet_subnet_id  = data.azurerm_subnet.kubesubnet.id
     # dns_prefix     MISSING
@@ -220,4 +219,3 @@ resource "azurerm_kubernetes_cluster" "test" {
   ]
   tags = var.tags
 }
-

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-# # Locals block for hardcoded names. 
+# # Locals block for hardcoded names.
 locals {
   backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
   frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
@@ -12,82 +12,82 @@ locals {
   app_gateway_subnet_name = "appgwsubnet"
 }
 
-#Resources 
+#Resources
 data "azurerm_resource_group" "rg" {
-  name = "${var.resource_group_name}"
+  name = var.resource_group_name
 }
 
-# User Assigned Idntities 
+# User Assigned Idntities
 resource "azurerm_user_assigned_identity" "testIdentity" {
-  resource_group_name = "${data.azurerm_resource_group.rg.name}"
-  location            = "${data.azurerm_resource_group.rg.location}"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = data.azurerm_resource_group.rg.location
 
   name = "identity1"
 
-  tags = "${var.tags}"
+  tags = var.tags
 }
 
 #Virtual Networks
 resource "azurerm_virtual_network" "test" {
-  name                = "${var.virtual_network_name}"
-  location            = "${data.azurerm_resource_group.rg.location}"
-  resource_group_name = "${data.azurerm_resource_group.rg.name}"
-  address_space       = ["${var.virtual_network_address_prefix}"]
+  name                = var.virtual_network_name
+  location            = data.azurerm_resource_group.rg.location
+  resource_group_name = data.azurerm_resource_group.rg.name
+  address_space       = [var.virtual_network_address_prefix]
 
   subnet {
-    name           = "${var.aks_subnet_name}"
-    address_prefix = "${var.aks_subnet_address_prefix}" # Kubernetes Subnet Address prefix
+    name           = var.aks_subnet_name
+    address_prefix = var.aks_subnet_address_prefix # Kubernetes Subnet Address prefix
   }
 
   subnet {
-    name           = "appgwsubnet"                              # Has to be hardcoded to this name.
-    address_prefix = "${var.app_gateway_subnet_address_prefix}"
+    name           = "appgwsubnet" # Has to be hardcoded to this name.
+    address_prefix = var.app_gateway_subnet_address_prefix
   }
 
-  tags = "${var.tags}"
+  tags = var.tags
 }
 
 data "azurerm_subnet" "kubesubnet" {
-  name                 = "${var.aks_subnet_name}"
-  virtual_network_name = "${azurerm_virtual_network.test.name}"
-  resource_group_name  = "${data.azurerm_resource_group.rg.name}"
+  name                 = var.aks_subnet_name
+  virtual_network_name = azurerm_virtual_network.test.name
+  resource_group_name  = data.azurerm_resource_group.rg.name
 }
 
 data "azurerm_subnet" "appgwsubnet" {
-  name                 = "appgwsubnet"                            #Hardcoded to this name. 
-  virtual_network_name = "${azurerm_virtual_network.test.name}"
-  resource_group_name  = "${data.azurerm_resource_group.rg.name}"
+  name                 = "appgwsubnet" #Hardcoded to this name.
+  virtual_network_name = azurerm_virtual_network.test.name
+  resource_group_name  = data.azurerm_resource_group.rg.name
 }
 
-# Public Ip 
+# Public Ip
 resource "azurerm_public_ip" "test" {
   name                         = "publicIp1"
-  location                     = "${data.azurerm_resource_group.rg.location}"
-  resource_group_name          = "${data.azurerm_resource_group.rg.name}"
+  location                     = data.azurerm_resource_group.rg.location
+  resource_group_name          = data.azurerm_resource_group.rg.name
   public_ip_address_allocation = "static"
   sku                          = "Standard"
 
-  tags = "${var.tags}"
+  tags = var.tags
 }
 
 resource "azurerm_application_gateway" "network" {
-  name                = "${var.app_gateway_name}"
-  resource_group_name = "${data.azurerm_resource_group.rg.name}"
-  location            = "${data.azurerm_resource_group.rg.location}"
+  name                = var.app_gateway_name
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = data.azurerm_resource_group.rg.location
 
   sku {
-    name     = "${var.app_gateway_sku}"
+    name     = var.app_gateway_sku
     tier     = "Standard_v2"
     capacity = 2
   }
 
   gateway_ip_configuration {
     name      = "appGatewayIpConfig"
-    subnet_id = "${data.azurerm_subnet.appgwsubnet.id}"
+    subnet_id = data.azurerm_subnet.appgwsubnet.id
   }
 
   frontend_port {
-    name = "${local.frontend_port_name}"
+    name = local.frontend_port_name
     port = 80
   }
 
@@ -97,16 +97,16 @@ resource "azurerm_application_gateway" "network" {
   }
 
   frontend_ip_configuration {
-    name                 = "${local.frontend_ip_configuration_name}"
-    public_ip_address_id = "${azurerm_public_ip.test.id}"
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test.id
   }
 
   backend_address_pool {
-    name = "${local.backend_address_pool_name}"
+    name = local.backend_address_pool_name
   }
 
   backend_http_settings {
-    name                  = "${local.http_setting_name}"
+    name                  = local.http_setting_name
     cookie_based_affinity = "Disabled"
     port                  = 80
     protocol              = "Http"
@@ -114,66 +114,75 @@ resource "azurerm_application_gateway" "network" {
   }
 
   http_listener {
-    name                           = "${local.listener_name}"
-    frontend_ip_configuration_name = "${local.frontend_ip_configuration_name}"
-    frontend_port_name             = "${local.frontend_port_name}"
+    name                           = local.listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name
     protocol                       = "Http"
   }
 
   request_routing_rule {
-    name                       = "${local.request_routing_rule_name}"
+    name                       = local.request_routing_rule_name
     rule_type                  = "Basic"
-    http_listener_name         = "${local.listener_name}"
-    backend_address_pool_name  = "${local.backend_address_pool_name}"
-    backend_http_settings_name = "${local.http_setting_name}"
+    http_listener_name         = local.listener_name
+    backend_address_pool_name  = local.backend_address_pool_name
+    backend_http_settings_name = local.http_setting_name
   }
 
-  tags = "${var.tags}"
+  tags = var.tags
 
-  depends_on = ["azurerm_virtual_network.test", "azurerm_public_ip.test"]
+  depends_on = [
+    azurerm_virtual_network.test,
+    azurerm_public_ip.test,
+  ]
 }
 
 resource "azurerm_role_assignment" "ra1" {
-  scope                = "${data.azurerm_subnet.kubesubnet.id}"
+  scope                = data.azurerm_subnet.kubesubnet.id
   role_definition_name = "Network Contributor"
-  principal_id         = "${var.aks_service_principal_object_id }"
+  principal_id         = var.aks_service_principal_object_id
 
-  depends_on = ["azurerm_virtual_network.test"]
+  depends_on = [azurerm_virtual_network.test]
 }
 
 resource "azurerm_role_assignment" "ra2" {
-  scope                = "${azurerm_user_assigned_identity.testIdentity.id}"
+  scope                = azurerm_user_assigned_identity.testIdentity.id
   role_definition_name = "Managed Identity Operator"
-  principal_id         = "${var.aks_service_principal_object_id}"
-  depends_on           = ["azurerm_user_assigned_identity.testIdentity"]
+  principal_id         = var.aks_service_principal_object_id
+  depends_on           = [azurerm_user_assigned_identity.testIdentity]
 }
 
 resource "azurerm_role_assignment" "ra3" {
-  scope                = "${azurerm_application_gateway.network.id}"
+  scope                = azurerm_application_gateway.network.id
   role_definition_name = "Contributor"
-  principal_id         = "${azurerm_user_assigned_identity.testIdentity.principal_id}"
-  depends_on           = ["azurerm_user_assigned_identity.testIdentity", "azurerm_application_gateway.network"]
+  principal_id         = azurerm_user_assigned_identity.testIdentity.principal_id
+  depends_on = [
+    azurerm_user_assigned_identity.testIdentity,
+    azurerm_application_gateway.network,
+  ]
 }
 
 resource "azurerm_role_assignment" "ra4" {
-  scope                = "${data.azurerm_resource_group.rg.id}"
+  scope                = data.azurerm_resource_group.rg.id
   role_definition_name = "Reader"
-  principal_id         = "${azurerm_user_assigned_identity.testIdentity.principal_id}"
-  depends_on           = ["azurerm_user_assigned_identity.testIdentity", "azurerm_application_gateway.network"]
+  principal_id         = azurerm_user_assigned_identity.testIdentity.principal_id
+  depends_on = [
+    azurerm_user_assigned_identity.testIdentity,
+    azurerm_application_gateway.network,
+  ]
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name       = "${var.aks_name}"
-  location   = "${data.azurerm_resource_group.rg.location}"
-  dns_prefix = "${var.aks_dns_prefix}"
+  name       = var.aks_name
+  location   = data.azurerm_resource_group.rg.location
+  dns_prefix = var.aks_dns_prefix
 
-  resource_group_name = "${data.azurerm_resource_group.rg.name}"
+  resource_group_name = data.azurerm_resource_group.rg.name
 
   linux_profile {
-    admin_username = "${var.vm_user_name}"
+    admin_username = var.vm_user_name
 
     ssh_key {
-      key_data = "${file(var.public_ssh_key_path)}"
+      key_data = file(var.public_ssh_key_path)
     }
   }
 
@@ -185,27 +194,30 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   agent_pool_profile {
     name            = "agentpool"
-    count           = "${var.aks_agent_count}"
-    vm_size         = "${var.aks_agent_vm_size}"
+    count           = var.aks_agent_count
+    vm_size         = var.aks_agent_vm_size
     os_type         = "Linux"
-    os_disk_size_gb = "${var.aks_agent_os_disk_size}"
-    vnet_subnet_id  = "${data.azurerm_subnet.kubesubnet.id}"
-
+    os_disk_size_gb = var.aks_agent_os_disk_size
+    vnet_subnet_id  = data.azurerm_subnet.kubesubnet.id
     # dns_prefix     MISSING
   }
 
   service_principal {
-    client_id     = "${var.aks_service_principal_app_id}"
-    client_secret = "${var.aks_service_principal_client_secret}"
+    client_id     = var.aks_service_principal_app_id
+    client_secret = var.aks_service_principal_client_secret
   }
 
   network_profile {
     network_plugin     = "azure"
-    dns_service_ip     = "${var.aks_dns_service_ip}"
-    docker_bridge_cidr = "${var.aks_docker_bridge_cidr}"
-    service_cidr       = "${var.aks_service_cidr}"
+    dns_service_ip     = var.aks_dns_service_ip
+    docker_bridge_cidr = var.aks_docker_bridge_cidr
+    service_cidr       = var.aks_service_cidr
   }
 
-  depends_on = ["azurerm_virtual_network.test", "azurerm_application_gateway.network"]
-  tags       = "${var.tags}"
+  depends_on = [
+    azurerm_virtual_network.test,
+    azurerm_application_gateway.network,
+  ]
+  tags = var.tags
 }
+

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "azurerm_public_ip" "test" {
   name                         = "publicIp1"
   location                     = data.azurerm_resource_group.rg.location
   resource_group_name          = data.azurerm_resource_group.rg.name
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
   sku                          = "Standard"
 
   tags = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -50,30 +50,28 @@ variable "app_gateway_subnet_address_prefix" {
 
 variable "app_gateway_name" {
   description = "Name of the Application Gateway."
-  default = "ApplicationGateway1"
+  default     = "ApplicationGateway1"
 }
 
 variable "app_gateway_sku" {
   description = "Name of the Application Gateway SKU."
-  default = "Standard_v2"
+  default     = "Standard_v2"
 }
-
 
 variable "app_gateway_tier" {
   description = "Tier of the Application Gateway SKU."
-  default = "Standard_v2"
+  default     = "Standard_v2"
 }
-
 
 variable "aks_name" {
   description = "Name of the AKS cluster."
   default     = "aks-cluster1"
 }
+
 variable "aks_dns_prefix" {
   description = "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
   default     = "aks"
 }
-
 
 variable "aks_agent_os_disk_size" {
   description = "Disk size (in GB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
@@ -126,9 +124,10 @@ variable "public_ssh_key_path" {
 }
 
 variable "tags" {
-  type = "map"
+  type = map(string)
 
   default = {
     source = "terraform"
   }
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Ran the `terraform 0.12upgrade` command which resolved the string interpolation warnings and created a `versions.tf` file explicitly stating that terraform 0.12.x + is required.

Resolved two azurerm changes that are currently throwing deprecated property warnings.
* public_ip_address_allocation -> allocation_method
* agent_pool_profile -> default_node_pool